### PR TITLE
new check: 'opentype/code_pages'

### DIFF
--- a/profile-universal/src/checks/code_pages.rs
+++ b/profile-universal/src/checks/code_pages.rs
@@ -1,0 +1,41 @@
+use fontspector_checkapi::{prelude::*, testfont, FileTypeConvert};
+use read_fonts::TableProvider;
+
+#[check(
+    id = "opentype/code_pages",
+    title = "Check code page character ranges",
+    rationale = "
+        At least some programs (such as Word and Sublime Text) under Windows 7
+        do not recognize fonts unless code page bits are properly set on the
+        ulCodePageRange1 (and/or ulCodePageRange2) fields of the OS/2 table.
+
+        More specifically, the fonts are selectable in the font menu, but whichever
+        Windows API these applications use considers them unsuitable for any
+        character set, so anything set in these fonts is rendered with Arial as a
+        fallback font.
+
+        This check currently does not identify which code pages should be set.
+        Auto-detecting coverage is not trivial since the OpenType specification
+        leaves the interpretation of whether a given code page is \"functional\"
+        or not open to the font developer to decide.
+
+        So here we simply detect as a FAIL when a given font has no code page
+        declared at all.
+    ",
+    proposal = "https://github.com/fonttools/fontbakery/issues/2474"
+)]
+fn code_pages(t: &Testable, _context: &Context) -> CheckFnResult {
+    let f = testfont!(t);
+    let os2 = f.font().os2()?;
+    let cpr1 = os2.ul_code_page_range_1();
+    let cpr2 = os2.ul_code_page_range_2();
+    if !cpr1.is_some() || !cpr2.is_some() || ((cpr1 == Some(0)) && (cpr2 == Some(0))) {
+        Ok(Status::just_one_fail(
+            "no-code-pages",
+            "No code pages defined in the OS/2 table ulCodePageRange1 \
+             and CodePageRange2 fields.",
+        ))
+    } else {
+        Ok(Status::just_one_pass())
+    }
+}

--- a/profile-universal/src/checks/mod.rs
+++ b/profile-universal/src/checks/mod.rs
@@ -1,5 +1,6 @@
 pub mod arabic_spacing_symbols;
 pub mod bold_italic_unique;
+pub mod code_pages;
 pub mod fvar;
 pub mod glyphnames;
 pub mod head;

--- a/profile-universal/src/lib.rs
+++ b/profile-universal/src/lib.rs
@@ -6,26 +6,17 @@ pub struct Universal;
 
 impl fontspector_checkapi::Plugin for Universal {
     fn register(&self, cr: &mut Registry) -> Result<(), String> {
-        cr.register_check(checks::arabic_spacing_symbols::arabic_spacing_symbols);
+
+        // For the OpenType profile:
         cr.register_check(checks::bold_italic_unique::bold_italic_unique);
         cr.register_check(checks::code_pages::code_pages);
         cr.register_check(checks::fvar::axis_ranges_correct);
         cr.register_check(checks::fvar::regular_coords_correct);
-        cr.register_check(checks::glyphnames::valid_glyphnames);
-        cr.register_check(checks::head::equal_font_versions);
-        cr.register_check(checks::head::font_version);
-        cr.register_check(checks::head::mac_style);
-        cr.register_check(checks::head::unitsperem);
         cr.register_check(checks::hhea::caret_slope);
         cr.register_check(checks::hhea::maxadvancewidth);
-        cr.register_check(checks::name_trailing_spaces::name_trailing_spaces);
-        cr.register_check(checks::name::name_empty_records);
-        cr.register_check(checks::os2::fsselection);
         cr.register_check(checks::post::post_table_version);
         cr.register_check(checks::post::underline_thickness);
-        cr.register_check(checks::required_tables::required_tables);
         cr.register_check(checks::stat::stat_axis_record);
-        cr.register_check(checks::unwanted_tables::unwanted_tables);
 
         let opentype_profile = Profile::from_toml(
             r#"
@@ -113,6 +104,14 @@ impl fontspector_checkapi::Plugin for Universal {
         )
         .map_err(|_| "Couldn't parse profile")?;
         cr.register_profile("opentype", opentype_profile)?;
+
+        // For the Universal profile:
+        cr.register_check(checks::arabic_spacing_symbols::arabic_spacing_symbols);
+        cr.register_check(checks::glyphnames::valid_glyphnames);
+        cr.register_check(checks::name::name_empty_records);
+        cr.register_check(checks::name_trailing_spaces::name_trailing_spaces);
+        cr.register_check(checks::required_tables::required_tables);
+        cr.register_check(checks::unwanted_tables::unwanted_tables);
 
         let universal_profile = Profile::from_toml(
             r#"

--- a/profile-universal/src/lib.rs
+++ b/profile-universal/src/lib.rs
@@ -8,6 +8,7 @@ impl fontspector_checkapi::Plugin for Universal {
     fn register(&self, cr: &mut Registry) -> Result<(), String> {
         cr.register_check(checks::arabic_spacing_symbols::arabic_spacing_symbols);
         cr.register_check(checks::bold_italic_unique::bold_italic_unique);
+        cr.register_check(checks::code_pages::code_pages);
         cr.register_check(checks::fvar::axis_ranges_correct);
         cr.register_check(checks::fvar::regular_coords_correct);
         cr.register_check(checks::glyphnames::valid_glyphnames);


### PR DESCRIPTION
"Check code page character ranges"
Added to the OpenType profile.

- Ported from https://github.com/fonttools/fontbakery/commit/33632eba19c5b8a9f75f4ce268db7dd7f987e44c#diff-5569a41870a06c4a294ea526c79f9720798989c0075e9e5e63a05eb6323d7d98R273-R314
- Originally proposed at https://github.com/fonttools/fontbakery/issues/2474