### PR TITLE
Move 'name/no_copyright_on_description' to Universal profile.

### DIFF
--- a/profile-opentype/src/checks/name.rs
+++ b/profile-opentype/src/checks/name.rs
@@ -37,36 +37,6 @@ fn name_empty_records(t: &Testable, _context: &Context) -> CheckFnResult {
 }
 
 #[check(
-    id = "opentype/name/no_copyright_on_description",
-    rationale = "
-        The name table in a font file contains strings about the font;
-        there are entries for a copyright field and a description. If the
-        copyright entry is being used correctly, then there should not
-        be any copyright information in the description entry.
-    ",
-    proposal = "https://github.com/fonttools/fontbakery/issues/4829",
-    title = "Description strings in the name table must not contain copyright info"
-)]
-fn check_name_no_copyright_on_description(t: &Testable, _context: &Context) -> CheckFnResult {
-    let f = testfont!(t);
-    let mut problems: Vec<Status> = vec![];
-    for record in f.get_name_entry_strings(NameId::DESCRIPTION) {
-        if record.contains("opyright") {
-            problems.push(Status::fail(
-                "copyright-on-description",
-                &format!(
-                    "Some namerecords with  ID={} (NameID.DESCRIPTION) containing copyright info
-should be removed (perhaps these were added by a longstanding FontLab Studio
-5.x bug that copied copyright notices to them.)",
-                    NameId::DESCRIPTION.to_u16()
-                ),
-            ))
-        }
-    }
-    return_result(problems)
-}
-
-#[check(
     id = "opentype/name/match_familyname_fullfont",
     rationale = r#"
         The FULL_FONT_NAME entry in the ‘name’ table should start with the same string

--- a/profile-opentype/src/lib.rs
+++ b/profile-opentype/src/lib.rs
@@ -31,7 +31,6 @@ impl fontspector_checkapi::Plugin for OpenType {
         cr.register_check(checks::layout::layout_valid_language_tags);
         cr.register_check(checks::layout::layout_valid_script_tags);
         cr.register_check(checks::name::check_name_match_familyname_fullfont);
-        cr.register_check(checks::name::check_name_no_copyright_on_description);
         cr.register_check(checks::name::consistent_family_name);
         cr.register_check(checks::name::family_max_4_fonts_per_family_name);
         cr.register_check(checks::name::family_naming_recommendations);
@@ -54,7 +53,6 @@ impl fontspector_checkapi::Plugin for OpenType {
 [sections]
 "OpenType Specification Checks" = [
     # Checks which we have definitely ported already
-    "name/trailing_spaces",
     "opentype/caret_slope",
     "opentype/family_naming_recommendations",
     "opentype/family/bold_italic_unique_for_nameid1",
@@ -109,7 +107,6 @@ impl fontspector_checkapi::Plugin for OpenType {
     "opentype/kern_table",
     "opentype/loca/maxp_num_glyphs",
     "opentype/monospace",
-    "opentype/name/no_copyright_on_description",
     "opentype/name/postscript_name_consistency",
     "opentype/name/postscript_vs_cff",
 

--- a/profile-universal/src/checks/mod.rs
+++ b/profile-universal/src/checks/mod.rs
@@ -1,5 +1,6 @@
 pub mod arabic_spacing_symbols;
 pub mod glyphnames;
+pub mod name_no_copyright_on_description;
 pub mod name_trailing_spaces;
 pub mod required_tables;
 pub mod unwanted_tables;

--- a/profile-universal/src/checks/name_no_copyright_on_description.rs
+++ b/profile-universal/src/checks/name_no_copyright_on_description.rs
@@ -1,0 +1,33 @@
+use font_types::NameId;
+use fontspector_checkapi::{prelude::*, testfont, FileTypeConvert};
+
+#[check(
+    id = "name/no_copyright_on_description",
+    rationale = "
+        The name table in a font file contains strings about the font;
+        there are entries for a copyright field and a description. If the
+        copyright entry is being used correctly, then there should not
+        be any copyright information in the description entry.
+    ",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4829",
+    title = "Description strings in the name table must not contain copyright info"
+)]
+fn name_no_copyright_on_description(t: &Testable, _context: &Context) -> CheckFnResult {
+    let f = testfont!(t);
+    let mut problems: Vec<Status> = vec![];
+    for record in f.get_name_entry_strings(NameId::DESCRIPTION) {
+        if record.contains("opyright") {
+            problems.push(Status::fail(
+                "copyright-on-description",
+                &format!(
+                    "Some namerecords with  ID={} (NameID.DESCRIPTION) containing copyright info
+should be removed (perhaps these were added by a longstanding FontLab Studio
+5.x bug that copied copyright notices to them.)",
+                    NameId::DESCRIPTION.to_u16()
+                ),
+            ))
+        }
+    }
+    return_result(problems)
+}
+

--- a/profile-universal/src/lib.rs
+++ b/profile-universal/src/lib.rs
@@ -8,6 +8,7 @@ impl fontspector_checkapi::Plugin for Universal {
     fn register(&self, cr: &mut Registry) -> Result<(), String> {
         cr.register_check(checks::arabic_spacing_symbols::arabic_spacing_symbols);
         cr.register_check(checks::glyphnames::valid_glyphnames);
+        cr.register_check(checks::name_no_copyright_on_description::name_no_copyright_on_description);
         cr.register_check(checks::name_trailing_spaces::name_trailing_spaces);
         cr.register_check(checks::required_tables::required_tables);
         cr.register_check(checks::unwanted_tables::unwanted_tables);
@@ -38,6 +39,7 @@ include_profiles = ["opentype"]
     # Checks which we have definitely ported already
     "arabic_spacing_symbols",
     "valid_glyphnames",
+    "name/no_copyright_on_description",
     "name/trailing_spaces",
     "required_tables",
 


### PR DESCRIPTION
Adding copyright information to the description name entry is bad practice but is not a breach of specification.

(https://github.com/fonttools/fontbakery/issues/4857)