### PR TITLE
Move 'name/italic_names' to Universal profile.

### DIFF
--- a/profile-opentype/src/checks/name.rs
+++ b/profile-opentype/src/checks/name.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use font_types::NameId;
-use fontspector_checkapi::{prelude::*, skip, testfont, FileTypeConvert};
+use fontspector_checkapi::{prelude::*, testfont, FileTypeConvert};
 use read_fonts::TableProvider;
 use skrifa::MetadataProvider;
 
@@ -190,65 +190,6 @@ fn family_naming_recommendations(t: &Testable, _context: &Context) -> CheckFnRes
                     ),
                 ));
             }
-        }
-    }
-    return_result(problems)
-}
-
-#[check(
-    id = "opentype/name/italic_names",
-    rationale = "
-        This check ensures that several entries in the name table
-        conform to the font's Upright or Italic style,
-        namely IDs 1 & 2 as well as 16 & 17 if they're present.
-    ",
-    proposal = "https://github.com/fonttools/fontbakery/issues/3666",
-    title = "Check name table IDs 1, 2, 16, 17 to conform to Italic style."
-)]
-fn name_italic_names(t: &Testable, _context: &Context) -> CheckFnResult {
-    let font = testfont!(t);
-    let mut problems = vec![];
-    skip!(
-        !font.filename_suggests_italic(),
-        "not-italic",
-        "Font is not italic"
-    );
-    if let Some(family_name) = font.get_name_entry_strings(NameId::FAMILY_NAME).next() {
-        if family_name.contains("Italic") {
-            problems.push(Status::fail(
-                "bad-familyname",
-                "Name ID 1 (Family Name) must not contain 'Italic'.",
-            ));
-        }
-    }
-    if let Some(subfamily_name) = font.get_name_entry_strings(NameId::SUBFAMILY_NAME).next() {
-        if subfamily_name != "Italic" && subfamily_name != "Bold Italic" {
-            problems.push(Status::fail(
-                "bad-subfamilyname",
-                &format!("Name ID 2 (Subfamily Name) does not conform to specs. Only R/I/B/BI are allowed, found {}", subfamily_name)
-            ));
-        }
-    }
-    if let Some(typo_family_name) = font
-        .get_name_entry_strings(NameId::TYPOGRAPHIC_FAMILY_NAME)
-        .next()
-    {
-        if typo_family_name.contains("Italic") {
-            problems.push(Status::fail(
-                "bad-typographicfamilyname",
-                "Name ID 16 (Typographic Family Name) must not contain 'Italic'.",
-            ));
-        }
-    }
-    if let Some(typo_subfamily_name) = font
-        .get_name_entry_strings(NameId::TYPOGRAPHIC_SUBFAMILY_NAME)
-        .next()
-    {
-        if !typo_subfamily_name.ends_with("Italic") {
-            problems.push(Status::fail(
-                "bad-typographicsubfamilyname",
-                "Name ID 16 (Typographic Family Name) must contain 'Italic'.",
-            ));
         }
     }
     return_result(problems)

--- a/profile-opentype/src/lib.rs
+++ b/profile-opentype/src/lib.rs
@@ -35,7 +35,6 @@ impl fontspector_checkapi::Plugin for OpenType {
         cr.register_check(checks::name::family_max_4_fonts_per_family_name);
         cr.register_check(checks::name::family_naming_recommendations);
         cr.register_check(checks::name::name_empty_records);
-        cr.register_check(checks::name::name_italic_names);
         cr.register_check(checks::name::postscript_name);
         cr.register_check(checks::os2::check_vendor_id);
         cr.register_check(checks::os2::fsselection);
@@ -74,7 +73,6 @@ impl fontspector_checkapi::Plugin for OpenType {
     "opentype/mac_style",
     "opentype/maxadvancewidth",
     "opentype/name/empty_records",
-    "opentype/name/italic_names",
     "opentype/name/match_familyname_fullfont",
     "opentype/points_out_of_bounds",
     "opentype/postscript_name",

--- a/profile-universal/src/checks/mod.rs
+++ b/profile-universal/src/checks/mod.rs
@@ -1,5 +1,6 @@
 pub mod arabic_spacing_symbols;
 pub mod glyphnames;
+pub mod name_italic_names;
 pub mod name_no_copyright_on_description;
 pub mod name_trailing_spaces;
 pub mod required_tables;

--- a/profile-universal/src/checks/name_italic_names.rs
+++ b/profile-universal/src/checks/name_italic_names.rs
@@ -1,0 +1,61 @@
+use font_types::NameId;
+use fontspector_checkapi::{prelude::*, skip, testfont, FileTypeConvert};
+
+#[check(
+    id = "name/italic_names",
+    rationale = "
+        This check ensures that several entries in the name table
+        conform to the font's Upright or Italic style,
+        namely IDs 1 & 2 as well as 16 & 17 if they're present.
+    ",
+    proposal = "https://github.com/fonttools/fontbakery/issues/3666",
+    title = "Check name table IDs 1, 2, 16, 17 to conform to Italic style."
+)]
+fn name_italic_names(t: &Testable, _context: &Context) -> CheckFnResult {
+    let font = testfont!(t);
+    let mut problems = vec![];
+    skip!(
+        !font.filename_suggests_italic(),
+        "not-italic",
+        "Font is not italic"
+    );
+    if let Some(family_name) = font.get_name_entry_strings(NameId::FAMILY_NAME).next() {
+        if family_name.contains("Italic") {
+            problems.push(Status::fail(
+                "bad-familyname",
+                "Name ID 1 (Family Name) must not contain 'Italic'.",
+            ));
+        }
+    }
+    if let Some(subfamily_name) = font.get_name_entry_strings(NameId::SUBFAMILY_NAME).next() {
+        if subfamily_name != "Italic" && subfamily_name != "Bold Italic" {
+            problems.push(Status::fail(
+                "bad-subfamilyname",
+                &format!("Name ID 2 (Subfamily Name) does not conform to specs. Only R/I/B/BI are allowed, found {}", subfamily_name)
+            ));
+        }
+    }
+    if let Some(typo_family_name) = font
+        .get_name_entry_strings(NameId::TYPOGRAPHIC_FAMILY_NAME)
+        .next()
+    {
+        if typo_family_name.contains("Italic") {
+            problems.push(Status::fail(
+                "bad-typographicfamilyname",
+                "Name ID 16 (Typographic Family Name) must not contain 'Italic'.",
+            ));
+        }
+    }
+    if let Some(typo_subfamily_name) = font
+        .get_name_entry_strings(NameId::TYPOGRAPHIC_SUBFAMILY_NAME)
+        .next()
+    {
+        if !typo_subfamily_name.ends_with("Italic") {
+            problems.push(Status::fail(
+                "bad-typographicsubfamilyname",
+                "Name ID 16 (Typographic Family Name) must contain 'Italic'.",
+            ));
+        }
+    }
+    return_result(problems)
+}

--- a/profile-universal/src/lib.rs
+++ b/profile-universal/src/lib.rs
@@ -8,6 +8,7 @@ impl fontspector_checkapi::Plugin for Universal {
     fn register(&self, cr: &mut Registry) -> Result<(), String> {
         cr.register_check(checks::arabic_spacing_symbols::arabic_spacing_symbols);
         cr.register_check(checks::glyphnames::valid_glyphnames);
+        cr.register_check(checks::name_italic_names::name_italic_names);
         cr.register_check(checks::name_no_copyright_on_description::name_no_copyright_on_description);
         cr.register_check(checks::name_trailing_spaces::name_trailing_spaces);
         cr.register_check(checks::required_tables::required_tables);
@@ -39,6 +40,7 @@ include_profiles = ["opentype"]
     # Checks which we have definitely ported already
     "arabic_spacing_symbols",
     "valid_glyphnames",
+    "name/italic_names",
     "name/no_copyright_on_description",
     "name/trailing_spaces",
     "required_tables",


### PR DESCRIPTION
This check uses the filename to determine whether the font should have various italic bits set. File naming is a matter for the OpenType specification, so this should be under Universal.

(https://github.com/fonttools/fontbakery/issues/4858)