### PR TITLE
googlefonts: usweightclass and fvar_instances checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ pluginator = "1.0.1"
 
 # Font-related deps
 read-fonts = "0"
-write-fonts = "0"
+write-fonts = "0.33.1"
 skrifa = "0"
 # Don't use font-types! Use the re-exported types from read-fonts instead.
 unicode-properties = "0.1.3"
@@ -36,3 +36,6 @@ itertools = "0.13.0"
 
 # Fontbakery bridge / Python module
 pyo3 = "0.22"
+
+indexmap = { version = "2", features = ["serde"] }
+markdown-table = "0.2.0"

--- a/fontspector-checkapi/Cargo.toml
+++ b/fontspector-checkapi/Cargo.toml
@@ -16,14 +16,13 @@ write-fonts = { workspace = true }
 skrifa = { workspace = true }
 fontspector-checkhelper = { workspace = true }
 log = { workspace = true }
-
-indexmap = { version = "2", features = ["serde"] }
+indexmap = { workspace = true }
 # Filetype
 glob-match = "0.2.1"
 glob = "0.3.1"
 
 # Needed so that we can refer to status codes on the command line
-clap = { version = "3.2.5", features = ["derive"], optional= true }
+clap = { version = "3.2.5", features = ["derive"], optional = true }
 
 # Serializing and deserializing profiles
 toml = "0.8.14"
@@ -32,4 +31,4 @@ serde = { workspace = true }
 # Storing configuration
 serde_json = "1.0"
 
-itertools = {workspace = true }
+itertools = { workspace = true }

--- a/fontspector-checkapi/src/constants.rs
+++ b/fontspector-checkapi/src/constants.rs
@@ -1,5 +1,14 @@
 use std::ops::Range;
 
+/// A font's outline type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutlineType {
+    /// TrueType outlines, with a glyf table and quadratic curves
+    TrueType,
+    /// CFF outlines, with a CFF table and cubic curves
+    CFF,
+}
+
 /// The names of the RIBBI styles
 pub const RIBBI_STYLE_NAMES: [&str; 5] = ["Regular", "Italic", "Bold", "BoldItalic", "Bold Italic"];
 /// A list of known static style names

--- a/fontspector-py/tests/test_checks_googlefonts.py
+++ b/fontspector-py/tests/test_checks_googlefonts.py
@@ -697,9 +697,8 @@ def test_check_glyph_coverage(check):
     assert_PASS(check(ttFont))
 
 
-@pytest.mark.skip("Check not ported yet.")
-@check_id("googlefonts/usweightclass")
-def test_check_usweightclass(check):
+@check_id("googlefonts/weightclass")
+def test_check_weightclass(check):
     """Checking OS/2 usWeightClass."""
 
     # Our reference Mada Regular is know to be bad here.
@@ -2357,7 +2356,6 @@ def test_check_varfont_has_HVAR(check):
     assert_results_contain(check(ttFont), FAIL, "lacks-HVAR")
 
 
-@pytest.mark.skip("Check not ported yet.")
 @check_id("googlefonts/fvar_instances")
 def test_check_fvar_instances__another_test(check):  # TODO: REVIEW THIS.
     """Check variable font instances."""
@@ -2378,7 +2376,6 @@ def test_check_fvar_instances__another_test(check):  # TODO: REVIEW THIS.
     assert_PASS(check(ttFont), "with a good font...")
 
 
-@pytest.mark.skip("Check not ported yet.")
 @check_id("googlefonts/fvar_instances")
 def test_check_fvar_instances__yet_another_test(check):  # TODO: REVIEW THIS.
     """A variable font must have named instances."""
@@ -2400,7 +2397,6 @@ def test_check_fvar_instances__yet_another_test(check):  # TODO: REVIEW THIS.
     )
 
 
-@pytest.mark.skip("Check not ported yet.")
 @check_id("googlefonts/fvar_instances")
 def test_check_fvar_instances__whats_going_on_here(check):  # TODO: REVIEW THIS.
     """Variable font weight coordinates must be multiples of 100."""
@@ -3099,7 +3095,6 @@ def test_check_cjk_vertical_metrics_regressions(check):
     )
 
 
-@pytest.mark.skip("Check not ported yet.")
 @check_id("googlefonts/fvar_instances")
 def test_check_varfont_instance_coordinates(check, vf_ttFont):
     # OpenSans-Roman-VF is correct
@@ -3640,7 +3635,6 @@ def test_check_metadata_category_hints(check):
         (TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"), [("Book", 450)], FAIL),
     ],
 )
-@pytest.mark.skip("Check not ported yet.")
 @check_id("googlefonts/fvar_instances")
 def test_check_fvar_instances(check, fp, mod, result):
     """Check font fvar instances are correct"""
@@ -3652,7 +3646,7 @@ def test_check_fvar_instances(check, fp, mod, result):
         for name, wght_val in mod:
             inst = NamedInstance()
             inst.subfamilyNameID = ttFont["name"].addName(name)
-            inst.coordinates = {"wght": wght_val}
+            inst.coordinates = {"wght": wght_val, "wdth": 100}
             ttFont["fvar"].instances.append(inst)
 
     if result == PASS:

--- a/profile-googlefonts/Cargo.toml
+++ b/profile-googlefonts/Cargo.toml
@@ -7,19 +7,22 @@ edition = "2021"
 reqwest = { version = "0.12", features = ["blocking"] }
 
 [dependencies]
-chrono = "0.4.38"                                           # For metadata date checks
+chrono = "0.4.38"                                                                                          # For metadata date checks
 fontspector-checkapi = { path = "../fontspector-checkapi" }
+google-fonts-axisregistry = { git = "https://github.com/googlefonts/axisregistry", branch = "rust-crate" }
 google-fonts-languages = "0"
 google-fonts-subsets = "0"
+indexmap = { workspace = true }
 itertools = { workspace = true }
+markdown-table = { workspace = true }
 protobuf = "3.7.1"
 read-fonts = { workspace = true }
-write-fonts = { workspace = true }
 regex = "1.10.6"
-skrifa = { workspace = true }
 serde_json = { workspace = true }
-
-unicode-properties = { workspace = true }
+skrifa = { workspace = true }
 unicode-normalization = "0"
+unicode-properties = { workspace = true }
+write-fonts = { workspace = true }
+
 [build-dependencies]
 protobuf-codegen = "3.7.1"

--- a/profile-googlefonts/src/checks/axes_match.rs
+++ b/profile-googlefonts/src/checks/axes_match.rs
@@ -1,5 +1,4 @@
 use fontspector_checkapi::{prelude::*, skip, testfont, FileTypeConvert};
-use skrifa::MetadataProvider;
 
 use crate::{metadata::family_proto, network_conditions::is_listed_on_google_fonts};
 

--- a/profile-googlefonts/src/checks/fvar_instances.rs
+++ b/profile-googlefonts/src/checks/fvar_instances.rs
@@ -1,0 +1,125 @@
+use std::vec;
+
+use fontspector_checkapi::{prelude::*, skip, testfont, FileTypeConvert, TestFont};
+use indexmap::{IndexMap, IndexSet};
+use markdown_table::{Heading, MarkdownTable};
+
+use crate::utils::build_expected_font;
+
+#[check(
+    id = "googlefonts/fvar_instances",
+    rationale = "
+        
+        Check a font's fvar instance coordinates comply with our guidelines:
+        https://googlefonts.github.io/gf-guide/variable.html#fvar-instances
+
+        This check is skipped for fonts that have a Morph (MORF) axis
+        since we allow users to define their own custom instances.
+    
+    ",
+    proposal = "https://github.com/fonttools/fontbakery/pull/3800",
+    title = "Check variable font instances"
+)]
+fn googlefonts_fvar_instances(t: &Testable, _context: &Context) -> CheckFnResult {
+    let f = testfont!(t);
+    let mut problems = vec![];
+    skip!(f.has_axis("MORF"), "has-morf", "Font has a MORF axis");
+    let expected_font_data = build_expected_font(&f, &[])?;
+    let expected_font = TestFont::new_from_data(&t.filename, &expected_font_data)
+        .map_err(|e| CheckError::Error(format!("Couldn't build expected font from data: {}", e)))?;
+    let instances: IndexMap<String, _> = f.named_instances().collect();
+    let expected_instances: IndexMap<String, _> = expected_font.named_instances().collect();
+    let mut table = vec![];
+    for name in instances.keys().chain(expected_instances.keys()) {
+        let mut row = IndexMap::new();
+        row.insert("Name".to_string(), name.to_string());
+        if let Some(font_instance) = instances.get(name) {
+            row.insert(
+                "current".to_string(),
+                font_instance
+                    .iter()
+                    .map(|(k, v)| format!("{}={}", k, v))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            );
+        }
+        if let Some(expected_instance) = expected_instances.get(name) {
+            row.insert(
+                "expected".to_string(),
+                expected_instance
+                    .iter()
+                    .map(|(k, v)| format!("{}={}", k, v))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            );
+        }
+        table.push(row);
+    }
+    table.sort_by(|a: &IndexMap<String, String>, b| a.get("expected").cmp(&b.get("expected")));
+    let expected_names: IndexSet<_> = expected_instances.keys().collect();
+    let current_names: IndexSet<_> = instances.keys().collect();
+    let missing_names = expected_names
+        .difference(&current_names)
+        .collect::<Vec<_>>();
+    let new_names = current_names
+        .difference(&expected_names)
+        .collect::<Vec<_>>();
+    let same_names = current_names
+        .intersection(&expected_names)
+        .collect::<Vec<_>>();
+    let wght_wrong = expected_instances.values().all(|i| i.contains_key("wght"))
+        && same_names
+            .iter()
+            .any(|i| instances[**i]["wght"] != expected_instances[**i]["wght"]);
+    let mut md_table = MarkdownTable::new(
+        table
+            .iter()
+            .map(|ix| {
+                vec![
+                    ix.get("Name").map_or("Unknown", |s| s.as_ref()),
+                    ix.get("current").map_or("N/A", |s| s.as_ref()),
+                    ix.get("expected").map_or("N/A", |s| s.as_ref()),
+                ]
+            })
+            .collect(),
+    );
+    md_table.with_headings(vec![
+        Heading::new("Name".to_string(), None),
+        Heading::new("current".to_string(), None),
+        Heading::new("expected".to_string(), None),
+    ]);
+    if wght_wrong || !missing_names.is_empty() || !new_names.is_empty() {
+        let mut hints = vec![];
+        if !missing_names.is_empty() {
+            hints.push("- Add missing instances");
+        }
+        if !new_names.is_empty() {
+            hints.push("- Delete additional instances");
+        }
+        if wght_wrong {
+            hints.push("- wght coordinates are wrong for some instances");
+        }
+        problems.push(Status::fail(
+            "bad-fvar-instances",
+            &format!(
+                "fvar instances are incorrect:\n\n{}\n\n{}\n\n",
+                hints.join("\n"),
+                md_table.as_markdown().map_err(|_| CheckError::Error(
+                    "Can't happen (table creation failed)".to_string()
+                ))?
+            ),
+        ));
+    } else if same_names
+        .into_iter()
+        .any(|i| instances[*i] != expected_instances[*i])
+    {
+        problems.push(Status::warn(
+            "suspicious-fvar-coords",
+            &format!(
+                "fvar instance coordinates for non-wght axes are not the same as the fvar defaults. This may be intentional so please check with the font author:\n\n{}\n\n",
+                md_table.as_markdown().map_err(|_| CheckError::Error("Can't happen (table creation failed)".to_string()))?
+            ),
+        ));
+    }
+    return_result(problems)
+}

--- a/profile-googlefonts/src/checks/googlefonts_weightclass.rs
+++ b/profile-googlefonts/src/checks/googlefonts_weightclass.rs
@@ -1,0 +1,95 @@
+use fontspector_checkapi::{constants::OutlineType, prelude::*, testfont, FileTypeConvert};
+use google_fonts_axisregistry::build_name_table;
+use read_fonts::TableProvider;
+use skrifa::FontRef;
+
+#[check(
+    id = "googlefonts/weightclass",
+    rationale = "
+        
+        Google Fonts expects variable fonts, static ttfs and static otfs to have
+        differing OS/2 usWeightClass values.
+
+        - For Variable Fonts, Thin-Black must be 100-900
+
+        - For static ttfs, Thin-Black can be 100-900 or 250-900
+
+        - For static otfs, Thin-Black must be 250-900
+
+        If static otfs are set lower than 250, text may appear blurry in
+        legacy Windows applications.
+
+        Glyphsapp users can change the usWeightClass value of an instance by adding
+        a 'weightClass' customParameter.
+    
+    ",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4829",
+    title = "Check the OS/2 usWeightClass is appropriate for the font's best SubFamily name."
+)]
+fn googlefonts_weightclass(t: &Testable, _context: &Context) -> CheckFnResult {
+    let f = testfont!(t);
+    let mut problems = vec![];
+    let value = f.font().os2()?.us_weight_class();
+    let expected_names = build_name_table(f.font(), None, None, &[])
+        .map_err(|e| CheckError::Error(e.to_string()))?;
+    let expected_value = FontRef::new(&expected_names)?.os2()?.us_weight_class();
+    let style_name = f.best_subfamilyname().unwrap_or("Regular".to_string());
+    if f.is_variable_font() {
+        if value != expected_value {
+            problems.push(Status::fail(
+                "bad-value",
+                &format!(
+                    "Best SubFamily name is '{}'. Expected OS/2 usWeightClass is {}, got {}.",
+                    style_name, expected_value, value
+                ),
+            ))
+        }
+    } else if style_name.contains("Thin") {
+        if f.outline_type() == OutlineType::TrueType && ![100, 250].contains(&value) {
+            problems.push(Status::fail(
+                "bad-value",
+                &format!(
+                    "Best SubFamily name is '{}'. Expected OS/2 usWeightClass is {}, got {}.",
+                    style_name, expected_value, value
+                ),
+            ))
+        }
+        if f.outline_type() == OutlineType::CFF && value != 250 {
+            problems.push(Status::fail(
+                "bad-value",
+                &format!(
+                    "Best SubFamily name is '{}'. Expected OS/2 usWeightClass is {}, got {}.",
+                    style_name, 250, value
+                ),
+            ))
+        }
+    } else if style_name.contains("ExtraLight") {
+        if f.outline_type() == OutlineType::TrueType && ![200, 275].contains(&value) {
+            problems.push(Status::fail(
+                "bad-value",
+                &format!(
+                    "Best SubFamily name is '{}'. Expected OS/2 usWeightClass is {}, got {}.",
+                    style_name, expected_value, value
+                ),
+            ))
+        }
+        if f.outline_type() == OutlineType::CFF && value != 275 {
+            problems.push(Status::fail(
+                "bad-value",
+                &format!(
+                    "Best SubFamily name is '{}'. Expected OS/2 usWeightClass is {}, got {}.",
+                    style_name, 275, value
+                ),
+            ))
+        }
+    } else if value != expected_value {
+        problems.push(Status::fail(
+            "bad-value",
+            &format!(
+                "Best SubFamily name is '{}'. Expected OS/2 usWeightClass is {}, got {}.",
+                style_name, expected_value, value
+            ),
+        ))
+    }
+    return_result(problems)
+}

--- a/profile-googlefonts/src/checks/mod.rs
+++ b/profile-googlefonts/src/checks/mod.rs
@@ -1,7 +1,7 @@
 pub mod axes_match;
 pub mod color_fonts;
 pub mod fstype;
-pub mod googlefonts_weightclass;
 pub mod name_description_max_length;
 pub mod render_own_name;
 pub mod tofu;
+pub mod weightclass;

--- a/profile-googlefonts/src/checks/mod.rs
+++ b/profile-googlefonts/src/checks/mod.rs
@@ -1,6 +1,7 @@
 pub mod axes_match;
 pub mod color_fonts;
 pub mod fstype;
+pub mod fvar_instances;
 pub mod name_description_max_length;
 pub mod render_own_name;
 pub mod tofu;

--- a/profile-googlefonts/src/checks/mod.rs
+++ b/profile-googlefonts/src/checks/mod.rs
@@ -1,6 +1,7 @@
 pub mod axes_match;
 pub mod color_fonts;
 pub mod fstype;
+pub mod googlefonts_weightclass;
 pub mod name_description_max_length;
 pub mod render_own_name;
 pub mod tofu;

--- a/profile-googlefonts/src/checks/tofu.rs
+++ b/profile-googlefonts/src/checks/tofu.rs
@@ -7,9 +7,9 @@ use unicode_normalization::UnicodeNormalization;
 use unicode_properties::{GeneralCategoryGroup, UnicodeGeneralCategory};
 
 struct OurLang<'a> {
-    id: String,
+    // id: String,
     name: String,
-    bases: Vec<char>,
+    // bases: Vec<char>,
     samples: Vec<(&'a str, String)>,
     supported: Option<String>,
 }
@@ -83,9 +83,9 @@ impl OurLang<'_> {
         // println!("{}: {:?}", lang.name(), supported);
         // }
         OurLang {
-            id: lang.id().to_owned(),
+            // id: lang.id().to_owned(),
             name: lang.name().to_owned(),
-            bases: bases.into_iter().collect(),
+            // bases: bases.into_iter().collect(),
             samples,
             supported,
         }

--- a/profile-googlefonts/src/checks/weightclass.rs
+++ b/profile-googlefonts/src/checks/weightclass.rs
@@ -1,7 +1,8 @@
 use fontspector_checkapi::{constants::OutlineType, prelude::*, testfont, FileTypeConvert};
-use google_fonts_axisregistry::build_name_table;
 use read_fonts::TableProvider;
 use skrifa::FontRef;
+
+use crate::utils::build_expected_font;
 
 #[check(
     id = "googlefonts/weightclass",
@@ -30,8 +31,7 @@ fn googlefonts_weightclass(t: &Testable, _context: &Context) -> CheckFnResult {
     let f = testfont!(t);
     let mut problems = vec![];
     let value = f.font().os2()?.us_weight_class();
-    let expected_names = build_name_table(f.font(), None, None, &[])
-        .map_err(|e| CheckError::Error(e.to_string()))?;
+    let expected_names = build_expected_font(&f, &[])?;
     let expected_value = FontRef::new(&expected_names)?.os2()?.us_weight_class();
     let style_name = f.best_subfamilyname().unwrap_or("Regular".to_string());
     if f.is_variable_font() {

--- a/profile-googlefonts/src/lib.rs
+++ b/profile-googlefonts/src/lib.rs
@@ -23,7 +23,7 @@ impl fontspector_checkapi::Plugin for GoogleFonts {
         cr.register_check(checks::axes_match::axes_match);
         cr.register_check(checks::color_fonts::color_fonts);
         cr.register_check(checks::fstype::googlefonts_fstype);
-        cr.register_check(checks::googlefonts_weightclass::googlefonts_weightclass);
+        cr.register_check(checks::weightclass::googlefonts_weightclass);
         cr.register_check(checks::name_description_max_length::name_description_max_length);
         cr.register_check(checks::render_own_name::render_own_name);
         cr.register_check(checks::tofu::googlefonts_tofu);

--- a/profile-googlefonts/src/lib.rs
+++ b/profile-googlefonts/src/lib.rs
@@ -178,8 +178,6 @@ include_profiles = ["universal"]
     "googlefonts/STAT/axisregistry",
     "googlefonts/unitsperem",
     "googlefonts/weightclass",
-    "googlefonts/varfont/bold_wght_coord",
-    "googlefonts/varfont/duplicate_instance_names",
     "googlefonts/varfont/generate_static",
     "googlefonts/varfont/has_HVAR",
     "googlefonts/vendor_id",

--- a/profile-googlefonts/src/lib.rs
+++ b/profile-googlefonts/src/lib.rs
@@ -12,6 +12,7 @@ mod use_typo_metrics;
 use fontspector_checkapi::prelude::*;
 
 mod network_conditions;
+mod utils;
 
 pub struct GoogleFonts;
 impl fontspector_checkapi::Plugin for GoogleFonts {
@@ -23,6 +24,7 @@ impl fontspector_checkapi::Plugin for GoogleFonts {
         cr.register_check(checks::axes_match::axes_match);
         cr.register_check(checks::color_fonts::color_fonts);
         cr.register_check(checks::fstype::googlefonts_fstype);
+        cr.register_check(checks::fvar_instances::googlefonts_fvar_instances);
         cr.register_check(checks::weightclass::googlefonts_weightclass);
         cr.register_check(checks::name_description_max_length::name_description_max_length);
         cr.register_check(checks::render_own_name::render_own_name);

--- a/profile-googlefonts/src/lib.rs
+++ b/profile-googlefonts/src/lib.rs
@@ -23,6 +23,7 @@ impl fontspector_checkapi::Plugin for GoogleFonts {
         cr.register_check(checks::axes_match::axes_match);
         cr.register_check(checks::color_fonts::color_fonts);
         cr.register_check(checks::fstype::googlefonts_fstype);
+        cr.register_check(checks::googlefonts_weightclass::googlefonts_weightclass);
         cr.register_check(checks::name_description_max_length::name_description_max_length);
         cr.register_check(checks::render_own_name::render_own_name);
         cr.register_check(checks::tofu::googlefonts_tofu);
@@ -174,7 +175,9 @@ include_profiles = ["universal"]
     "googlefonts/STAT/axis_order",
     "googlefonts/STAT/axisregistry",
     "googlefonts/unitsperem",
-    "googlefonts/usweightclass",
+    "googlefonts/weightclass",
+    "googlefonts/varfont/bold_wght_coord",
+    "googlefonts/varfont/duplicate_instance_names",
     "googlefonts/varfont/generate_static",
     "googlefonts/varfont/has_HVAR",
     "googlefonts/vendor_id",

--- a/profile-googlefonts/src/utils.rs
+++ b/profile-googlefonts/src/utils.rs
@@ -1,0 +1,22 @@
+use fontspector_checkapi::{CheckError, TestFont};
+use google_fonts_axisregistry::{build_fvar_instances, build_name_table, build_stat};
+use skrifa::FontRef;
+
+pub(crate) fn build_expected_font<'a>(
+    font: &'a TestFont,
+    siblings: &[&'a TestFont],
+) -> Result<Vec<u8>, CheckError> {
+    let mut new_binary = build_name_table(font.font(), None, None, &[], None)
+        .map_err(|e| CheckError::Error(e.to_string()))?;
+    let mut newfont = FontRef::new(&new_binary)?;
+    if font.is_variable_font() {
+        new_binary =
+            build_fvar_instances(newfont, None).map_err(|e| CheckError::Error(e.to_string()))?;
+        // And again...
+        newfont = FontRef::new(&new_binary)?;
+        let siblings: Vec<FontRef<'_>> = siblings.iter().map(|x| x.font()).collect();
+        new_binary =
+            build_stat(newfont, &siblings).map_err(|e| CheckError::Error(e.to_string()))?;
+    }
+    Ok(new_binary)
+}

--- a/profile-universal/Cargo.toml
+++ b/profile-universal/Cargo.toml
@@ -2,26 +2,30 @@
 name = "profile-universal"
 version = "0.1.0"
 edition = "2021"
-authors =  [
+authors = [
     "Simon Cozens <simon@simon-cozens.org>",
     "Felipe Sanches <juca@members.fsf.org>",
 ]
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-freetype-rs = { version = "*", features = ["bundled"] } # For freetype_rasterizer
+freetype-rs = { version = "*", features = [
+    "bundled",
+] } # For freetype_rasterizer
 reqwest = { version = "0.12", features = ["blocking"] } # For fontdata namecheck
 
 [dependencies]
-interpolatable = { git = "https://github.com/simoncozens/interpolatable", features = [ "skrifa"]} # For interpolation_issues
+interpolatable = { git = "https://github.com/simoncozens/interpolatable", features = [
+    "skrifa",
+] } # For interpolation_issues
 fontspector-checkapi = { path = "../fontspector-checkapi" }
 fontspector-checkhelper = { workspace = true }
-read-fonts = {workspace = true}
-write-fonts = {workspace = true}
-skrifa = {workspace = true}
-itertools = {workspace = true }
+read-fonts = { workspace = true }
+write-fonts = { workspace = true }
+skrifa = { workspace = true }
+itertools = { workspace = true }
 unicode-properties = { workspace = true }
 unicode_names2 = "0.6.0"
-markdown-table = "0.2.0"
-log = {workspace =  true}
+markdown-table = { workspace = true }
+log = { workspace = true }
 humansize = "2.1.3"
 serde_json = { workspace = true }


### PR DESCRIPTION
This ports the usweightclass and fvar_instances checks on the googlefonts profile. It currently uses a git branch of `axisregistry` to build the "expected" font names and weights. Once I've clarified a few STAT table issues with Marc, I'll release this as a published crate, but this is fine for development. 