### PR TITLE
when building wasm, disable checks that use the reqwest crate

### DIFF
--- a/profile-googlefonts/src/checks/googlefonts/description/mod.rs
+++ b/profile-googlefonts/src/checks/googlefonts/description/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_family = "wasm"))]
 mod broken_links;
 mod eof_linebreak;
 mod git_url;
@@ -7,6 +8,7 @@ mod min_length;
 mod urls;
 mod valid_html;
 
+#[cfg(not(target_family = "wasm"))]
 pub use broken_links::broken_links;
 pub use eof_linebreak::eof_linebreak;
 pub use git_url::git_url;

--- a/profile-googlefonts/src/lib.rs
+++ b/profile-googlefonts/src/lib.rs
@@ -73,8 +73,13 @@ impl fontspector_checkapi::Plugin for GoogleFonts {
             .add_section("Glyphset Checks")
             //            .add_and_register_check(checks::googlefonts::glyphsets::shape_languages)
             .add_and_register_check(checks::googlefonts::tofu)
-            .add_section("Description Checks")
-            .add_and_register_check(checks::googlefonts::description::broken_links)
+            .add_section("Description Checks");
+
+        #[cfg(not(target_family = "wasm"))]
+        let builder =
+            builder.add_and_register_check(checks::googlefonts::description::broken_links);
+
+        let builder = builder
             .add_and_register_check(checks::googlefonts::description::eof_linebreak)
             //            .add_and_register_check(checks::googlefonts::description::family_update)
             .add_and_register_check(checks::googlefonts::description::git_url)


### PR DESCRIPTION
I'm not exactly sure what went wrong here:
![image](https://github.com/user-attachments/assets/0a6c508f-db7f-42ae-892b-1a6fd1143cb1)

But I suspect that the reqwest crate may be be supported yet in wasm builds. If that's the case, this PR should fix the build. Otherwise, please help me understand what's going on.